### PR TITLE
Fix build using git-buildpackage on Debian unstable

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-mfoc-hardnested (0.10.9) unstable; urgency=medium
+mfoc-hardnested (0.10.9-1) unstable; urgency=medium
 
   * New upstream version 0.10.9
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: utils
 Priority: optional
 Maintainer: gelotus <gelotus@github.com>
 Uploaders: gelotus <gelotus@github.com>
-Build-Depends: debhelper (>= 11), libnfc-dev, pkg-config
+Build-Depends: debhelper (>= 11), libnfc-dev, liblzma-dev, pkg-config
 Standards-Version: 4.1.5
 Homepage: https://github.com/nfc-tools/mfoc-hardnested/
 

--- a/src/mfoc.c
+++ b/src/mfoc.c
@@ -65,6 +65,9 @@
 
 #define MAX_FRAME_LEN 264
 
+mftag        t;
+mfreader    r;
+
 static const nfc_modulation nm = {
 .nmt = NMT_ISO14443A,
 .nbr = NBR_106,

--- a/src/mfoc.h
+++ b/src/mfoc.h
@@ -87,8 +87,8 @@ typedef struct {
 } countKeys;
 
 
-mftag        t;
-mfreader    r;
+extern mftag        t;
+extern mfreader    r;
 
 
 void usage(FILE *stream, uint8_t errnr);


### PR DESCRIPTION
With those commits, the following steps will build a deb package in `/var/lib/debspawn/results`:

```
# apt-get install git-buildpackage debspawn
$ debspawn create sid
$ gbp buildpackage --git-builder='debspawn build sid' --git-upstream-tree=SLOPPY --git-force-create
```