### PR TITLE
Fixed compilation on ARM platforms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,25 +42,29 @@ AC_CHECK_FUNCS([memset])
 
 # x86 CPU features (without automatic gcc flags)
 AC_CANONICAL_HOST
-X86_SIMD=""
 AS_CASE([$host_cpu],
     [x86_64],
     [
         X86_SIMD="true"
+        CFLAGS="$CFLAGS -DX86_SIMD -std=c99"
     ],
     [i?86],
     [
         X86_SIMD="true"
+        CFLAGS="$CFLAGS -DX86_SIMD -std=c99"
     ],
     [amd64],
     [
         X86_SIMD="true"
-    ],)
+        CFLAGS="$CFLAGS -DX86_SIMD -std=c99"
+    ],
+    [default],
+    [
+        CFLAGS="$CFLAGS -std=c99"
+    ]
+)
 AC_SUBST([X86_SIMD])
 AM_CONDITIONAL([X86_SIMD], [test x$X86_SIMD = xtrue])
-
-# C99
-CFLAGS="$CFLAGS -DX86_SIMD -std=c99"
 
 AC_CONFIG_FILES([Makefile
                  src/Makefile])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -32,8 +32,8 @@ if X86_SIMD
 
 else
 
-  SIMDOBJ = hardnested/hardnested_bf_core_NOSIMD.o hardnested/hardnested_bitarray_core_NOSIMD.o
-  hardnested/%_NOSIMD.o : hardnested/%.c
+  SIMD = hardnested/hardnested_bf_core_NOSIMD.o hardnested/hardnested_bitarray_core_NOSIMD.o
+  hardnested/%_NOSIMD.o : hardnested/%_NOSIMD.c
 	$(CC) $(DEPFLAGS) $(CFLAGS) -c -o $@ $<
 
 endif


### PR DESCRIPTION
There is probably a cleaner way of doing this, but I'm not an expert. All I know is that MFOC now compiles on my Raspberry Pi 4 running Manjaro 64bit.

Previously we'd have issues with linking, as the autoreconf was not generating the `Makefile`(s) properly to compile `NOSIMD`.