### PR TITLE
Fix mistake in sector -> block conversion

### DIFF
--- a/src/cmdhfmfhard.h
+++ b/src/cmdhfmfhard.h
@@ -55,6 +55,7 @@ typedef struct noncelist {
 
 int mfnestedhard(uint8_t blockNo, uint8_t keyType, uint8_t *key, uint8_t trgBlockNo, uint8_t trgKeyType, bool hard_low_memory);
 void hardnested_print_progress(uint32_t nonces, char *activity, float brute_force, uint64_t min_diff_print_time, uint8_t trgKeyBlock, uint8_t trgKeyType, bool newline);
+uint8_t block_to_sector(uint8_t block);
 
 #endif
 

--- a/src/hardnested/hardnested_bruteforce.c
+++ b/src/hardnested/hardnested_bruteforce.c
@@ -152,11 +152,11 @@ crack_states_thread(void* x) {
                 char progress_text[80];
                 sprintf(progress_text, "Brute force phase completed. Key found: %012" PRIx64, key);
                 if (thread_arg->trgKey == MC_AUTH_A){
-                    t.sectors[thread_arg->trgBlock / 4].foundKeyA = true;
-                    num_to_bytes(key, 6, t.sectors[thread_arg->trgBlock / 4].KeyA);
+                    t.sectors[block_to_sector(thread_arg->trgBlock)].foundKeyA = true;
+                    num_to_bytes(key, 6, t.sectors[block_to_sector(thread_arg->trgBlock)].KeyA);
                 } else {
-                    t.sectors[thread_arg->trgBlock / 4].foundKeyB = true;
-                    num_to_bytes(key, 6, t.sectors[thread_arg->trgBlock / 4].KeyB);
+                    t.sectors[block_to_sector(thread_arg->trgBlock)].foundKeyB = true;
+                    num_to_bytes(key, 6, t.sectors[block_to_sector(thread_arg->trgBlock)].KeyB);
                 }
                 hardnested_print_progress(thread_arg->num_acquired_nonces, progress_text, 0.0, 0, thread_arg->trgBlock, thread_arg->trgKey, true);
                 break;

--- a/src/hardnested/hardnested_bruteforce.c
+++ b/src/hardnested/hardnested_bruteforce.c
@@ -56,6 +56,7 @@ THE SOFTWARE.
 #include "../util.h"
 #include "../util_posix.h"
 #include "../crapto1.h"
+#include "../cmdhfmfhard.h"
 #include "../parity.h"
 #include "../mifare.h"
 #include "../bf_bench_data.h"

--- a/src/mfoc.c
+++ b/src/mfoc.c
@@ -1267,7 +1267,7 @@ int mf_enhanced_auth(int e_sector, int a_sector, mftag t, mfreader r, denonce *d
   if (mode == 'h') {
     // Again, prepare the Auth command with MC_AUTH_A, recover the block and CRC
     Auth[0] = dumpKeysA ? MC_AUTH_A : MC_AUTH_B;
-    Auth[1] = a_sector * 4; //block
+    Auth[1] = sector_to_block(a_sector); //block
     iso14443a_crc_append(Auth, 2);
 
     // Encryption of the Auth command, sending the Auth command


### PR DESCRIPTION
This piece of code didn't use the sector_to_block function and as such the hardnested attack was broken for 4k cards, because those have larger sectors at the end of the card.